### PR TITLE
Update statistics chart layout

### DIFF
--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/StatisticsFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/StatisticsFragment.kt
@@ -34,6 +34,9 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlin.math.floor
+import kotlin.math.log10
+import kotlin.math.pow
 
 @AndroidEntryPoint
 class StatisticsFragment : Fragment() {
@@ -286,15 +289,11 @@ class StatisticsFragment : Fragment() {
 
             axisLeft.apply {
                 val maxY = dataSet.yMax
-                val minY = dataSet.yMin
-                val range = maxY - minY
-                val extra = if (range == 0f) maxY * 0.1f else range * 0.1f
-                val top = maxY + extra
-                val bottom = if (minY > 0f) 0f else minY
-                val step = (top - bottom) / 5f
-                setAxisMinimum(bottom)
+                val step = computeAxisStep(maxY)
+                val top = ((maxY / step).toInt() + 1) * step
+                setAxisMinimum(0f)
                 setAxisMaximum(top)
-                setLabelCount(6, true)
+                setLabelCount((top / step).toInt() + 1, true)
                 granularity = step
                 valueFormatter = object : com.github.mikephil.charting.formatter.ValueFormatter() {
                     override fun getFormattedValue(value: Float): String = value.toKString()
@@ -311,6 +310,20 @@ class StatisticsFragment : Fragment() {
             animateX(500)
             invalidate()
         }
+    }
+
+    private fun computeAxisStep(maxValue: Float): Float {
+        if (maxValue <= 0f) return 1f
+        val raw = maxValue / 5f
+        val magnitude = 10f.pow(floor(log10(raw)))
+        val residual = raw / magnitude
+        val step = when {
+            residual <= 1f -> 1f
+            residual <= 2f -> 2f
+            residual <= 5f -> 5f
+            else -> 10f
+        }
+        return step * magnitude
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_statistics.xml
+++ b/app/src/main/res/layout/fragment_statistics.xml
@@ -95,17 +95,23 @@
                 android:textStyle="bold"/>
         </LinearLayout>
 
-        <!-- 3. График -->
-        <com.github.mikephil.charting.charts.LineChart
-            android:id="@+id/lineChart"
+        <!-- 3. Responsive chart wrapper with 16:9 ratio -->
+        <FrameLayout
+            android:id="@+id/chartWrapper"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
-            android:background="@drawable/bg_chart_panel"
             app:layout_constraintTop_toBottomOf="@id/cardGoals"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHeight_percent="0.32"/>
+            app:layout_constraintDimensionRatio="16:9">
+
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/lineChart"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/bg_chart_panel"/>
+        </FrameLayout>
 
         <!-- 4. Top Months заголовок -->
         <TextView
@@ -119,7 +125,7 @@
             android:textColor="#FFFFFF"
             android:textSize="18sp"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/lineChart"
+            app:layout_constraintTop_toBottomOf="@id/chartWrapper"
             app:layout_constraintStart_toStartOf="parent"/>
 
         <!-- 5. Top Months RecyclerView -->


### PR DESCRIPTION
## Summary
- match chart container ratio in `fragment_statistics.xml` to Progress screen
- show an extra grid square above the largest value in the statistics chart
- scale Progress chart Y axis the same way as Statistics chart

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e1fc0704832a8ed03e25fd0825e4